### PR TITLE
remove tab before and add space after `\texttt` in documentation

### DIFF
--- a/luaquotes-documentation.tex
+++ b/luaquotes-documentation.tex
@@ -142,7 +142,7 @@ breaklines,
 A limitation on the (de-)activation of the package is that the Lua filters will not deactivate within the same paragraph, so the function can only be changed across paragraphs.
 
 \subsection{Monospace}
-As a general rule, smart quotes are rather undesirable in monospace text, and therefore, within the \color{darkspringgreen}\verb!	\texttt!\color{black} environment the package does not apply smart quotes. Thus, the same input produces in roman face \textcolor{darkspringgreen}{"Hello World"} but in monospace \texttt{"Hello World"}.
+As a general rule, smart quotes are rather undesirable in monospace text, and therefore, within the \color{darkspringgreen}\verb!\texttt! \color{black} environment the package does not apply smart quotes. Thus, the same input produces in roman face \textcolor{darkspringgreen}{"Hello World"} but in monospace \texttt{"Hello World"}.
 	
 	As the example above shows, the default behaviour of this package forces straight quotes in monospace, and disables \TeX\ quote ligatures (but not other \TeX\ ligatures) to do so, on the assumption that any form of curved quotes are undesirable.  
 	


### PR DESCRIPTION
In section on monospace. Doesn't look good the way it is.